### PR TITLE
Add validity/caching period to status list credentials.

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@ defined in the Verifiable Credentials Data Model specification in
 Section 4.6: Validity Period</a>. Implementations that consume the status list
 SHOULD cache the status list <a>verifiable credential</a> until this
 time. Implementations that publish the status list are expected to align
-any protocol specific caching information, such as the HTTP `Cache-Control`
+any protocol-specific caching information, such as the HTTP `Cache-Control`
 header, with the value in this field.
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -428,6 +428,28 @@ express a <code>type</code> property that includes the
               </td>
             </tr>
             <tr>
+              <td>validFrom</td>
+              <td>
+The earliest point in time at which the status list is valid. This property is
+defined in the Verifiable Credentials Data Model specification in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#validity-period">
+Section 4.6: Validity Period</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>validUntil</td>
+              <td>
+The latest point in time at which the status list is valid. This property is
+defined in the Verifiable Credentials Data Model specification in
+<a href="https://www.w3.org/TR/vc-data-model-2.0/#validity-period">
+Section 4.6: Validity Period</a>. Implementations that consume the status list
+SHOULD cache the status list <a>verifiable credential</a> until this
+time. Implementations that publish the status list are expected to align
+any protocol specific caching information, such as the HTTP `Cache-Control`
+header, with the value in this field.
+              </td>
+            </tr>
+            <tr>
               <td>credentialSubject.type</td>
               <td>
 The <code>type</code> of the credential <a>subject</a>, which is the


### PR DESCRIPTION
This PR addresses issue #38 by specifying validity and caching behaviour for status list credentials.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-status-list-2021/pull/53.html" title="Last updated on Mar 6, 2023, 8:42 PM UTC (a399c83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-status-list-2021/53/ca50a56...a399c83.html" title="Last updated on Mar 6, 2023, 8:42 PM UTC (a399c83)">Diff</a>