### PR TITLE
Support for multiple status codes

### DIFF
--- a/index.html
+++ b/index.html
@@ -562,15 +562,9 @@ bitstring. Further information on bitstring encoding can be found in Section
                 </ul>
                 Implementers MAY add additional values to objects in the <code>statusMessages</code>
                 array.
-                Implementers MAY add a boolean value to elements in the <code>statusMessages</code>
-                named <code>verify</code> which adds an instruction to verifiers where if the
-                value of <code>verify</code> is <code>true</code> the verifier SHOULD not
                 use the status to reject verification of the verifiable credential. If the
                 value of <code>verify</code> is <code>false</code>, then a verifier SHOULD
                 NOT verify the verifiable credential.
-                If <code>verify</code> is present, then the values of `0` and `1` should 
-                be processed identically to the values of `0` and `1` in a status list with a
-                <code>statusPurpose<code> of <code>suspension</code>.
                 Implementers MAY use the string value of <code>undefined</code> in the value
                 to indicate that a status corresponding is not defined for the associated
                 status value, but that it may be definied in the future.
@@ -636,9 +630,9 @@ bitstring. Further information on bitstring encoding can be found in Section
               "reference": "https://example.org/status-dictionary/"
               "size": 2
               "statusMessages": [ 
-                  {"status":"0x0", "value":"valid", "verify": true},
-                  {"status":"0x1", "value":"invalid", "verify": false},
-                  {"status":"0x2", "value":"pending_review", "verify": true},
+                  {"status":"0x0", "value":"valid"},
+                  {"status":"0x1", "value":"invalid"},
+                  {"status":"0x2", "value":"pending_review"},
                   ...
               ],
               "encodedList": "H4sIAAAAAAAAA-3BMQEAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"

--- a/index.html
+++ b/index.html
@@ -490,6 +490,7 @@ This status is reversible.
 Used to indicate a status message associated with a <a>verifiable credential</a>.
 The status message descriptions MUST be defined in <code>credentialStatus.message</code>.
 <code>credentialStatus.size</code> MUST be defined with this <code>statusPurpose</code>.
+<p class="issue" data-number="66">We need to add an example for multiple status codes</p>
                       </td>
                     </tr>
                   </tbody>

--- a/index.html
+++ b/index.html
@@ -633,6 +633,7 @@ bitstring. Further information on bitstring encoding can be found in Section
               "ttl": 500,
               "statusPurpose": "<span class="highlight">status</span>",
               "reference": "https://example.org/status-dictionary/"
+              "size": 2
               "statusMessages": [ 
                   {"status":"0x0", "value":"valid", "verify": true},
                   {"status":"0x1", "value":"invalid", "verify": false},

--- a/index.html
+++ b/index.html
@@ -686,7 +686,7 @@ Generate a <strong>revocation bitstring</strong> by passing
         <li>
 Let <strong>status</strong> be the value at position indicated by the
 <strong>credentialIndex</strong> times the <strong>size</strong> in the 
-<strong>revocation bitstring</strong>.
+<strong>bitstring</strong>.
         </li>
         <li>
 For <code>statusPurpose</code> of <code>revocation</code> or <code>suspension</code> 

--- a/index.html
+++ b/index.html
@@ -534,8 +534,6 @@ bitstring. Further information on bitstring encoding can be found in Section
               </td>
               <td>
                 The <code>size</code> indicates the size of the status entry in bits.
-                If size is omitted then the size of each status entry is assumed to be
-                one bit (and therefore capable of capturing a boolean status).
                 <code>size</code> MAY be provided, but if <code>size</code> is not present
                 as a property of the <code>credentialStatus</code> then <code>size</code>
                 MUST be processed as `1`.  <code>size</code> MUST be greater than zero.

--- a/index.html
+++ b/index.html
@@ -565,7 +565,7 @@ bitstring. Further information on bitstring encoding can be found in Section
                 Implementers MAY add additional values to objects in the <code>message</code>
                 array.
                 Implementers MAY use the string value of <code>undefined</code> in the value
-                to indidate that a status corresponding is not definied for the associated
+                to indicate that a status corresponding is not defined for the associated
                 status value, but that it may be definied in the future.
                 Rules for how to handle various status messages are outside the scope of
                 normative reuqirements in this document, but it is assumed that implementers

--- a/index.html
+++ b/index.html
@@ -534,10 +534,10 @@ bitstring. Further information on bitstring encoding can be found in Section
               </td>
               <td>
                 The <code>size</code> indicates the size of the status entry in bits.
-                <code>size</code> MAY be provided, but if <code>size</code> is not present
-                as a property of the <code>credentialStatus</code> then <code>size</code>
+                <code>size</code> MAY be provided. If <code>size</code> is not present
+                as a property of the <code>credentialStatus</code>, then <code>size</code>
                 MUST be processed as `1`.  <code>size</code> MUST be an integer greater than zero.
-                if <code>size</code> is provided, and is greater than `1`, then the property
+                If <code>size</code> is provided and is greater than `1`, then the property
                 <code>credentialStatus.statusMessages</code> MUST be present, and the number of
                 status messages must equal the number of possible values.
               </td>
@@ -547,18 +547,18 @@ bitstring. Further information on bitstring encoding can be found in Section
                 credentialSubject.statusMessages
               </td>
               <td>
-                The <code>statusMessages</code> property MUST be an array, and if present
+                The <code>statusMessages</code> property MUST be an array. If present,
                 the length of the array must equal the number of possible status states
                 indicated by <code>size</code>. <code>statusMessages</code> MAY be present if
                 <code>size</code> is `1`. <code>statusMessages</code> MUST be present if
                 <code>size</code> is greater than `1`.  If not present, the message value
                 associated with the bit value of <code>0</code> is "unset" and the bit
                 value of <code>1</code> is "set".
-                Elements in the <code>statusMessages</code> array if present, MUST contain at 
+                If present, elements in the <code>statusMessages</code> array MUST contain at 
                 minimum two properties:
                 <ul>
-                  <li><code>status</code> being a string of the hex value of the status</li>
-                  <li><code>value</code> a string containing the associated message</li>
+                  <li><code>status</code>, being a string of the hex value of the status</li>
+                  <li><code>value</code>, being a string containing the associated message</li>
                 </ul>
                 Implementers MAY add additional values to objects in the <code>statusMessages</code>
                 array.

--- a/index.html
+++ b/index.html
@@ -535,11 +535,11 @@ bitstring. Further information on bitstring encoding can be found in Section
               <td>
                 The <code>size</code> indicates the size of the status entry in bits.
                 If size is omitted then the size of each status entry is assumed to be
-                1 bit (and therefore capable of capturing a boolean status).
+                one bit (and therefore capable of capturing a boolean status).
                 <code>size</code> MAY be provided, but if <code>size</code> is not present
                 as a property of the <code>credentialStatus</code> then <code>size</code>
-                MUST be processed as 1.  <code>size</code> MUST be greater than zero.
-                if <code>size</code> is provided, and is greater than 1, then the property
+                MUST be processed as `1`.  <code>size</code> MUST be greater than zero.
+                if <code>size</code> is provided, and is greater than `1`, then the property
                 <code>credentialStatus.message</code> MUST be present, and the number of
                 status messages must equal the number of possible values.
               </td>
@@ -552,8 +552,8 @@ bitstring. Further information on bitstring encoding can be found in Section
                 The <code>message</code> property MUST be an array, and if present
                 the length of the array must equal the number of possible status states
                 indicated by <code>size</code>. <code>message</code> MAY be present if
-                <code>size</code> is 1. <code>message</code> MUST be present if
-                <code>size</code> is greater than 1.  If not present, the message value
+                <code>size</code> is `1`. <code>message</code> MUST be present if
+                <code>size</code> is greater than `1`.  If not present, the message value
                 associated with the bit value of <code>0</code> is "unset" and the bit
                 value of <code>1</code> is "set".
                 Elements in the <code>message</code> array if present, MUST contain at 
@@ -690,7 +690,7 @@ Let <strong>status</strong> be the value at position indicated by the
         </li>
         <li>
 For <code>statusPurpose</code> of <code>revocation</code> or <code>suspension</code> 
-return <code>true</code> if <strong>status</strong> is 1, <code>false</code>
+return <code>true</code> if <strong>status</strong> is `1`, <code>false</code>
 otherwise.  Otherwise, return the corresponding <code>value</code> of the status
 as indicated in the <code>message</code> array.
         </li>

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@ This status is reversible.
                       <td><code>status</code></td>
                       <td>
 Used to indicate a status message associated with a <a>verifiable credential</a>.
-The status message descriptions MUST be defined in <code>credentialSubject.message</code>.
+The status message descriptions MUST be defined in <code>credentialSubject.statusMessages</code>.
 <code>credentialSubject.size</code> MUST be defined with this <code>statusPurpose</code>.
 <p class="issue" data-number="66">We need to add an example for multiple status codes</p>
                       </td>
@@ -540,31 +540,31 @@ bitstring. Further information on bitstring encoding can be found in Section
                 as a property of the <code>credentialStatus</code> then <code>size</code>
                 MUST be processed as `1`.  <code>size</code> MUST be greater than zero.
                 if <code>size</code> is provided, and is greater than `1`, then the property
-                <code>credentialStatus.message</code> MUST be present, and the number of
+                <code>credentialStatus.statusMessages</code> MUST be present, and the number of
                 status messages must equal the number of possible values.
               </td>
             </tr>
             <tr>
               <td>
-                credentialSubject.message
+                credentialSubject.statusMessages
               </td>
               <td>
-                The <code>message</code> property MUST be an array, and if present
+                The <code>statusMessages</code> property MUST be an array, and if present
                 the length of the array must equal the number of possible status states
-                indicated by <code>size</code>. <code>message</code> MAY be present if
-                <code>size</code> is `1`. <code>message</code> MUST be present if
+                indicated by <code>size</code>. <code>statusMessages</code> MAY be present if
+                <code>size</code> is `1`. <code>statusMessages</code> MUST be present if
                 <code>size</code> is greater than `1`.  If not present, the message value
                 associated with the bit value of <code>0</code> is "unset" and the bit
                 value of <code>1</code> is "set".
-                Elements in the <code>message</code> array if present, MUST contain at 
+                Elements in the <code>statusMessages</code> array if present, MUST contain at 
                 minimum two properties:
                 <ul>
                   <li><code>status</code> being a string of the hex value of the status</li>
                   <li><code>value</code> a string containing the associated message</li>
                 </ul>
-                Implementers MAY add additional values to objects in the <code>message</code>
+                Implementers MAY add additional values to objects in the <code>statusMessages</code>
                 array.
-                Implementers MAY add a boolean value to elements in the <code>message</code>
+                Implementers MAY add a boolean value to elements in the <code>statusMessages</code>
                 named <code>verify</code> which adds an instruction to verifiers where if the
                 value of <code>verify</code> is <code>true</code> the verifier SHOULD not
                 use the status to reject verification of the verifiable credential. If the
@@ -633,7 +633,7 @@ bitstring. Further information on bitstring encoding can be found in Section
               "ttl": 500,
               "statusPurpose": "<span class="highlight">status</span>",
               "reference": "https://example.org/status-dictionary/"
-              "message": [ 
+              "statusMessages": [ 
                   {"status":"0x0", "value":"valid", "verify": true},
                   {"status":"0x1", "value":"invalid", "verify": false},
                   {"status":"0x2", "value":"pending_review", "verify": true},
@@ -741,7 +741,7 @@ Let <strong>status</strong> be the value at position indicated by the
 For <code>statusPurpose</code> of <code>revocation</code> or <code>suspension</code> 
 return <code>true</code> if <strong>status</strong> is `1`, <code>false</code>
 otherwise.  Otherwise, return the corresponding <code>value</code> of the status
-as indicated in the <code>message</code> array.
+as indicated in the <code>statusMessages</code> array.
         </li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -521,7 +521,7 @@ bitstring. Further information on bitstring encoding can be found in Section
                 This property MAY be present, but if not present, implementers MUST 
                 use a value of <code>300000</code> for this property.  A verifier
                 MUST NOT use a cached <code>StatusList2021Credential</code> that was
-                cached more for more than the <code>ttl</code> duration prior to the
+                cached for more than the <code>ttl</code> duration prior to the
                 start of verification operation on a <a>verifiable credential</a>.
                 Implementations that publish the status list SHOULD align
                 any protocol-specific caching information, such as the 

--- a/index.html
+++ b/index.html
@@ -608,7 +608,10 @@ bitstring. Further information on bitstring encoding can be found in Section
   "proof": { ... }
 }
         </pre>
-        <pre class="example nohighlight" title="Example StatusList2021Credential">
+                <p class="issue" data-number="73" title="Design of multiple status messages is not finalized.">
+The Working Group is still discussing the unification of a design between status lists with a single state (such as "revoked" or "suspended") and status lists with multiple states (exposed via a series of status messages). We are seeking implementer feedback on what a unified design should look like from an ease of implementation, privacy, and security standpoint.
+                </p>
+                <pre class="example nohighlight" title="Example StatusList2021Credential">
           {
             "@context": [
               "https://www.w3.org/2018/credentials/v1",

--- a/index.html
+++ b/index.html
@@ -490,7 +490,6 @@ This status is reversible.
 Used to indicate a status message associated with a <a>verifiable credential</a>.
 The status message descriptions MUST be defined in <code>credentialSubject.statusMessages</code>.
 <code>credentialSubject.size</code> MUST be defined with this <code>statusPurpose</code>.
-<p class="issue" data-number="66">We need to add an example for multiple status codes</p>
                       </td>
                     </tr>
                   </tbody>

--- a/index.html
+++ b/index.html
@@ -568,6 +568,9 @@ bitstring. Further information on bitstring encoding can be found in Section
                 use the status to reject verification of the verifiable credential. If the
                 value of <code>verify</code> is <code>false</code>, then a verifier SHOULD
                 NOT verify the verifiable credential.
+                If <code>verify</verify> is present, then the values of `0` and `1` should 
+                be processed identically to the values of `0` and `1` in a status list with a
+                <code>statusPurpose<code> of <code>suspension</code>.
                 Implementers MAY use the string value of <code>undefined</code> in the value
                 to indicate that a status corresponding is not defined for the associated
                 status value, but that it may be definied in the future.

--- a/index.html
+++ b/index.html
@@ -518,7 +518,7 @@ bitstring. Further information on bitstring encoding can be found in Section
               </td>
               <td>
                 The <code>ttl</code> indicates the "time to live" in milliseconds.
-                This property MAY be present, but if not present, implementers MUST 
+                This property MAY be present. If not present, implementers MUST 
                 use a value of <code>300000</code> for this property.  A verifier
                 MUST NOT use a cached <code>StatusList2021Credential</code> that was
                 cached for more than the <code>ttl</code> duration prior to the
@@ -735,14 +735,15 @@ Generate a <strong>revocation bitstring</strong> by passing
 <a href="#bitstring-expansion-algorithm">Bitstring Expansion Algorithm</a>.
         </li>
         <li>
-Let <strong>status</strong> be the value at position indicated by the
+Let <strong>status</strong> be the value at the position indicated by the
 <strong>credentialIndex</strong> times the <strong>size</strong> in the 
 <strong>bitstring</strong>.
         </li>
         <li>
-For <code>statusPurpose</code> of <code>revocation</code> or <code>suspension</code> 
-return <code>true</code> if <strong>status</strong> is `1`, <code>false</code>
-otherwise.  Otherwise, return the corresponding <code>value</code> of the status
+For <code>statusPurpose</code> of <code>revocation</code> or <code>suspension</code>, 
+return <code>true</code> if <code>status</code> is `1`, and return <code>false</code>
+if <code>status</code> has any other value.  For other <code>statusPurpose</code>,
+return the corresponding <code>value</code> of the <code>status</code>
 as indicated in the <code>statusMessages</code> array.
         </li>
       </ol>
@@ -763,11 +764,11 @@ Let <strong>bitstring</strong> be a list of bits with a minimum size of 16KB,
 where each bit is initialized to 0 (zero).
         </li>
         <li>
-For each value in <strong>bitstring</strong>, if there is a
-corresponding <strong>statusListIndex</strong> value in
-a credential in <strong>issuedCredentials</strong>, set the value to the 
-appropriate status. The position of the value is computed as <strong>statusListIndex</strong>
-times the <strong>size</strong>.  
+For each value in <code>bitstring</code>, if there is a
+corresponding <code>statusListIndex</code> value in
+a credential in <code>issuedCredentials</code>, set the value to the 
+appropriate status. The position of the value is computed as <code>statusListIndex</code>
+times the <code>size</code>.  
         </li>
         <li>
 Generate a <strong>compressed bitstring</strong> by using the GZIP

--- a/index.html
+++ b/index.html
@@ -623,8 +623,8 @@ bitstring. Further information on bitstring encoding can be found in Section
               "type": "<span class="highlight">StatusList2021</span>",
               "ttl": 500,
               "statusPurpose": "<span class="highlight">status</span>",
-              "reference": "https://example.org/status-dictionary/"
-              "size": 2
+              "reference": "https://example.org/status-dictionary/",
+              "size": 2,
               "statusMessages": [ 
                   {"status":"0x0", "value":"valid"},
                   {"status":"0x1", "value":"invalid"},

--- a/index.html
+++ b/index.html
@@ -354,7 +354,7 @@ This status is reversible.
               <td>statusListIndex</td>
               <td>
 The <code>statusListIndex</code> property MUST be an arbitrary size integer
-greater than or equal to 0, expressed as a string. The value identifies the bit
+greater than or equal to 0, expressed as a string. The value identifies the
 position of the status of the <a>verifiable credential</a>.
               </td>
             </tr>
@@ -446,11 +446,7 @@ Section 4.6: Validity Period</a>.
 The latest point in time at which the status list is valid. This property is
 defined in the Verifiable Credentials Data Model specification in
 <a href="https://www.w3.org/TR/vc-data-model-2.0/#validity-period">
-Section 4.6: Validity Period</a>. Implementations that consume the status list
-SHOULD cache the status list <a>verifiable credential</a> until this
-time. Implementations that publish the status list are expected to align
-any protocol-specific caching information, such as the HTTP `Cache-Control`
-header, with the value in this field.
+Section 4.6: Validity Period</a>. 
               </td>
             </tr>
             <tr>
@@ -488,6 +484,14 @@ Used to temporarily prevent the acceptance of a <a>verifiable credential</a>.
 This status is reversible.
                       </td>
                     </tr>
+                    <tr>
+                      <td><code>status</code></td>
+                      <td>
+Used to indicate a status message associated with a <a>verifiable credential</a>.
+The status message descriptions MUST be defined in <code>credentialSubject.message</code>.
+<code>credentialSubject.size</code> MUST be defined with this <code>statusPurpose</code>.
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </td>
@@ -507,7 +511,66 @@ bitstring. Further information on bitstring encoding can be found in Section
 <a href="#bitstring-encoding"></a>.
               </td>
             </tr>
-
+            <tr>
+              <td>
+                credentialSubject.ttl
+              </td>
+              <td>
+                The <code>ttl</code> indicates the "time to live" in milliseconds.
+                This property MAY be present, but if not present, implementers MUST 
+                use a value of <code>300000</code> for this property.  A verifier
+                MUST not use a cached <code>StatusList2021Credential</code> that was
+                cached more for more than the <code>ttl</code> duration prior to the
+                start of verification operation on a <a>verifiable credential</a>.
+                Implementations that publish the status list SHOULD align
+                any protocol-specific caching information, such as the 
+                HTTP `Cache-Control` header, with the value in this field.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                credentialSubject.size
+              </td>
+              <td>
+                The <code>size</code> indicates the size of the status entry in bits.
+                If size is omitted then the size of each status entry is assumed to be
+                1 bit (and therefore capable of capturing a boolean status).
+                <code>size</code> MAY be provided, but if <code>size</code> is not present
+                as a property of the <code>credentialSubject</code> then <code>size</code>
+                MUST be processed as 1.  <code>size</code> MUST be greater than zero.
+                if <code>size</code> is provided, and is greater than 1, then the property
+                <code>credentialSubject.message</code> MUST be present, and the number of
+                status messages must equal the number of possible values.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                credentialSubject.message
+              </td>
+              <td>
+                The <code>message</code> property MUST be an array, and if present
+                the length of the array must equal the number of possible status states
+                indicated by <code>size</code>. <code>message</code> MAY be present if
+                <code>size</code> is 1. <code>message</code> MUST be present if
+                <code>size</code> is greater than 1.  If not present, the message value
+                associated with the bit value of <code>0</code> is "unset" and the bit
+                value of <code>1</code> is "set".
+                Elements in the <code>message</code> array if present, MUST contain at 
+                minimum two properties:
+                <ul>
+                  <li><code>status</code> being a string of the hex value of the status</li>
+                  <li><code>value</code> a string containing the associated message</li>
+                </ul>
+                Implementers MAY add additional values to objects in the <code>message</code>
+                array.
+                Implementers MAY use the string value of <code>undefined</code> in the value
+                to indidate that a status corresponding is not definied for the associated
+                status value, but that it may be definied in the future.
+                Rules for how to handle various status messages are outside the scope of
+                normative reuqirements in this document, but it is assumed that implementers
+                SHOULD and will document rules for processing various status codes.
+              </td>
+            </tr>
           </tbody>
         </table>
 
@@ -620,12 +683,15 @@ Generate a <strong>revocation bitstring</strong> by passing
 <a href="#bitstring-expansion-algorithm">Bitstring Expansion Algorithm</a>.
         </li>
         <li>
-Let <strong>status</strong> be the value of the bit at position
-<strong>credentialIndex</strong> in the <strong>revocation bitstring</strong>.
+Let <strong>status</strong> be the value at position indicated by the
+<strong>credentialIndex</strong> times the <strong>size</strong> in the 
+<strong>revocation bitstring</strong>.
         </li>
         <li>
-Return <code>true</code> if <strong>status</strong> is 1, <code>false</code>
-otherwise.
+For <code>statusPurpose</code> of <code>revocation</code> or <code>suspension</code> 
+return <code>true</code> if <strong>status</strong> is 1, <code>false</code>
+otherwise.  Otherwise, return the corresponding <code>value</code> of the status
+as indicated in the <code>message</code> array.
         </li>
       </ol>
     </section>
@@ -645,10 +711,11 @@ Let <strong>bitstring</strong> be a list of bits with a minimum size of 16KB,
 where each bit is initialized to 0 (zero).
         </li>
         <li>
-For each bit in <strong>bitstring</strong>, if there is a
-corresponding <code>statusListIndex</code> value in
-a revoked credential in <strong>issuedCredentials</strong>, set the bit to
-1 (one), otherwise set the bit to 0 (zero).
+For each value in <strong>bitstring</strong>, if there is a
+corresponding <strong>statusListIndex</strong> value in
+a credential in <strong>issuedCredentials</strong>, set the value to the 
+appropriate status.  The position of the value is computed as <strong>statusListIndex</strong>
+times the <strong>size</strong>.  
         </li>
         <li>
 Generate a <strong>compressed bitstring</strong> by using the GZIP

--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@ bitstring. Further information on bitstring encoding can be found in Section
                 use the status to reject verification of the verifiable credential. If the
                 value of <code>verify</code> is <code>false</code>, then a verifier SHOULD
                 NOT verify the verifiable credential.
-                If <code>verify</verify> is present, then the values of `0` and `1` should 
+                If <code>verify</code> is present, then the values of `0` and `1` should 
                 be processed identically to the values of `0` and `1` in a status list with a
                 <code>statusPurpose<code> of <code>suspension</code>.
                 Implementers MAY use the string value of <code>undefined</code> in the value

--- a/index.html
+++ b/index.html
@@ -488,8 +488,8 @@ This status is reversible.
                       <td><code>status</code></td>
                       <td>
 Used to indicate a status message associated with a <a>verifiable credential</a>.
-The status message descriptions MUST be defined in <code>credentialStatus.message</code>.
-<code>credentialStatus.size</code> MUST be defined with this <code>statusPurpose</code>.
+The status message descriptions MUST be defined in <code>credentialSubject.message</code>.
+<code>credentialSubject.size</code> MUST be defined with this <code>statusPurpose</code>.
 <p class="issue" data-number="66">We need to add an example for multiple status codes</p>
                       </td>
                     </tr>
@@ -514,7 +514,7 @@ bitstring. Further information on bitstring encoding can be found in Section
             </tr>
             <tr>
               <td>
-                credentialStatus.ttl
+                credentialSubject.ttl
               </td>
               <td>
                 The <code>ttl</code> indicates the "time to live" in milliseconds.
@@ -530,7 +530,7 @@ bitstring. Further information on bitstring encoding can be found in Section
             </tr>
             <tr>
               <td>
-                credentialStatus.size
+                credentialSubject.size
               </td>
               <td>
                 The <code>size</code> indicates the size of the status entry in bits.
@@ -546,7 +546,7 @@ bitstring. Further information on bitstring encoding can be found in Section
             </tr>
             <tr>
               <td>
-                credentialStatus.message
+                credentialSubject.message
               </td>
               <td>
                 The <code>message</code> property MUST be an array, and if present
@@ -564,12 +564,35 @@ bitstring. Further information on bitstring encoding can be found in Section
                 </ul>
                 Implementers MAY add additional values to objects in the <code>message</code>
                 array.
+                Implementers MAY add a boolean value to elements in the <code>message</code>
+                named <code>verify</code> which adds an instruction to verifiers where if the
+                value of <code>verify</code> is <code>true</code> the verifier SHOULD not
+                use the status to reject verification of the verifiable credential. If the
+                value of <code>verify</code> is <code>false</code>, then a verifier SHOULD
+                NOT verify the verifiable credential.
                 Implementers MAY use the string value of <code>undefined</code> in the value
                 to indicate that a status corresponding is not defined for the associated
                 status value, but that it may be definied in the future.
                 Rules for how to handle various status messages are outside the scope of
                 normative reuqirements in this document, but it is assumed that implementers
                 SHOULD and will document rules for processing various status codes.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                credentialSubject.reference
+              </td>
+              <td>
+                The <code>reference</code> property provides a point for implementers to
+                include a [[URL]] to material related to the status. An implementer MAY include
+                the <code>reference</code> property, and if they do, the value MUST be a
+                [[URL]] or an array of URLs. Implementers using a `statusPurpose` of `status`
+                are strongly encouraged to provide a <code>reference</code>.
+                <p class="note" title="Details around reference">
+                  <code>reference</code> is especially important when interpertation of the 
+                  status for a credential may involve some understanding of the business case
+                  involved.
+                </p>
               </td>
             </tr>
           </tbody>
@@ -593,6 +616,32 @@ bitstring. Further information on bitstring encoding can be found in Section
   },
   "proof": { ... }
 }
+        </pre>
+        <pre class="example nohighlight" title="Example StatusList2021Credential">
+          {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://w3id.org/vc/status-list/2021/v1"
+            ],
+            "id": "<span class="highlight">https://example.com/credentials/status/3</span>",
+            "type": ["VerifiableCredential", "<span class="highlight">StatusList2021Credential</span>"],
+            "issuer": "did:example:12345",
+            "issued": "2021-04-05T14:27:40Z",
+            "credentialSubject": {
+              "id": "https://example.com/status/3#list",
+              "type": "<span class="highlight">StatusList2021</span>",
+              "ttl": 500,
+              "statusPurpose": "<span class="highlight">status</span>",
+              "reference": "https://example.org/status-dictionary/"
+              "message": [ 
+                  {"status":"0x0", "value":"valid", "verify": true},
+                  {"status":"0x1", "value":"invalid", "verify": false},
+                  {"status":"0x2", "value":"pending_review", "verify": true},
+                  ...
+              ],
+              "encodedList": "H4sIAAAAAAAAA-3BMQEAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+            }
+          }
         </pre>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -566,11 +566,11 @@ bitstring. Further information on bitstring encoding can be found in Section
                 value of <code>verify</code> is <code>false</code>, then a verifier SHOULD
                 NOT verify the verifiable credential.
                 Implementers MAY use the string value of <code>undefined</code> in the value
-                to indicate that a status corresponding is not defined for the associated
-                status value, but that it may be definied in the future.
+                to indicate that a corresponding status is not defined for the associated
+                status value, but that it may be defined in the future.
                 Rules for how to handle various status messages are outside the scope of
-                normative reuqirements in this document, but it is assumed that implementers
-                SHOULD and will document rules for processing various status codes.
+                normative requirements in this document, but it is assumed that implementers
+                will document rules for processing various status codes.
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -488,8 +488,8 @@ This status is reversible.
                       <td><code>status</code></td>
                       <td>
 Used to indicate a status message associated with a <a>verifiable credential</a>.
-The status message descriptions MUST be defined in <code>credentialSubject.message</code>.
-<code>credentialSubject.size</code> MUST be defined with this <code>statusPurpose</code>.
+The status message descriptions MUST be defined in <code>credentialStatus.message</code>.
+<code>credentialStatus.size</code> MUST be defined with this <code>statusPurpose</code>.
                       </td>
                     </tr>
                   </tbody>
@@ -513,13 +513,13 @@ bitstring. Further information on bitstring encoding can be found in Section
             </tr>
             <tr>
               <td>
-                credentialSubject.ttl
+                credentialStatus.ttl
               </td>
               <td>
                 The <code>ttl</code> indicates the "time to live" in milliseconds.
                 This property MAY be present, but if not present, implementers MUST 
                 use a value of <code>300000</code> for this property.  A verifier
-                MUST not use a cached <code>StatusList2021Credential</code> that was
+                MUST NOT use a cached <code>StatusList2021Credential</code> that was
                 cached more for more than the <code>ttl</code> duration prior to the
                 start of verification operation on a <a>verifiable credential</a>.
                 Implementations that publish the status list SHOULD align
@@ -529,23 +529,23 @@ bitstring. Further information on bitstring encoding can be found in Section
             </tr>
             <tr>
               <td>
-                credentialSubject.size
+                credentialStatus.size
               </td>
               <td>
                 The <code>size</code> indicates the size of the status entry in bits.
                 If size is omitted then the size of each status entry is assumed to be
                 1 bit (and therefore capable of capturing a boolean status).
                 <code>size</code> MAY be provided, but if <code>size</code> is not present
-                as a property of the <code>credentialSubject</code> then <code>size</code>
+                as a property of the <code>credentialStatus</code> then <code>size</code>
                 MUST be processed as 1.  <code>size</code> MUST be greater than zero.
                 if <code>size</code> is provided, and is greater than 1, then the property
-                <code>credentialSubject.message</code> MUST be present, and the number of
+                <code>credentialStatus.message</code> MUST be present, and the number of
                 status messages must equal the number of possible values.
               </td>
             </tr>
             <tr>
               <td>
-                credentialSubject.message
+                credentialStatus.message
               </td>
               <td>
                 The <code>message</code> property MUST be an array, and if present

--- a/index.html
+++ b/index.html
@@ -715,7 +715,7 @@ where each bit is initialized to 0 (zero).
 For each value in <strong>bitstring</strong>, if there is a
 corresponding <strong>statusListIndex</strong> value in
 a credential in <strong>issuedCredentials</strong>, set the value to the 
-appropriate status.  The position of the value is computed as <strong>statusListIndex</strong>
+appropriate status. The position of the value is computed as <strong>statusListIndex</strong>
 times the <strong>size</strong>.  
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -562,9 +562,6 @@ bitstring. Further information on bitstring encoding can be found in Section
                 </ul>
                 Implementers MAY add additional values to objects in the <code>statusMessages</code>
                 array.
-                use the status to reject verification of the verifiable credential. If the
-                value of <code>verify</code> is <code>false</code>, then a verifier SHOULD
-                NOT verify the verifiable credential.
                 Implementers MAY use the string value of <code>undefined</code> in the value
                 to indicate that a corresponding status is not defined for the associated
                 status value, but that it may be defined in the future.

--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@ bitstring. Further information on bitstring encoding can be found in Section
                 The <code>size</code> indicates the size of the status entry in bits.
                 <code>size</code> MAY be provided, but if <code>size</code> is not present
                 as a property of the <code>credentialStatus</code> then <code>size</code>
-                MUST be processed as `1`.  <code>size</code> MUST be greater than zero.
+                MUST be processed as `1`.  <code>size</code> MUST be an integer greater than zero.
                 if <code>size</code> is provided, and is greater than `1`, then the property
                 <code>credentialStatus.statusMessages</code> MUST be present, and the number of
                 status messages must equal the number of possible values.


### PR DESCRIPTION
initial additions for better caching guidance and backwards compatible support for multiple status value support in a single status list

Edit to note that TTL introduces a breaking change behavior, but the multiple status handling is backwards compatible with boolean status lists


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mesur-io/vc-status-list-2021/pull/65.html" title="Last updated on Jun 22, 2023, 5:09 PM UTC (887f87e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-status-list-2021/65/aab9852...mesur-io:887f87e.html" title="Last updated on Jun 22, 2023, 5:09 PM UTC (887f87e)">Diff</a>